### PR TITLE
Add route paramters to OPA input.

### DIFF
--- a/src/OpenPolicyAgent.php
+++ b/src/OpenPolicyAgent.php
@@ -128,6 +128,7 @@ class OpenPolicyAgent implements EventSubscriberInterface, LoggerAwareInterface
                     'scheme' => $request->getScheme(),
                 ),
                 'resources' => array(
+                    'attributes' => $request->attributes->get('_route_params'),
                     'requirements' => $resources,
                 ),
             ),


### PR DESCRIPTION
Example: route /blog/{user}/{slug}
will have values for `user` and `slug` available in the decision context.