### PR TITLE
Tighter PDP endpoint construction.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "authors": [
         {
             "name": "Yash Tewari",
-            "email": "yashtewari1996@gmail.com"
+            "email": "yash@build.securty"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "symfony/flex": "^1.3.1",
         "symfony/framework-bundle": "5.2.*",
         "symfony/http-client": "5.2.*",
-        "symfony/yaml": "5.2.*"
+        "symfony/yaml": "5.2.*",
+        "busybee/urljoin": "dev-main"
     },
     "autoload": {
         "psr-4": {

--- a/example/README.md
+++ b/example/README.md
@@ -14,6 +14,7 @@ The authz policy that we're going to load into the Policy Decision Point (PDP) i
 2. The `member` role is assigned to registered users, who can create, update and delete _their own blogs_, but can only view other's blogs.
 3. The `admin` role is assigned to admins, who can access the admin console, as well as create, update and delete _anyone's blogs_.
 
+For the following steps, please make sure you have the [latest version of Docker](https://docs.docker.com/get-docker/) installed.
 #### Setting up the Policy Decision Point (PDP)
 
 Let's start up the OPA server using Docker on a separate terminal.
@@ -44,14 +45,11 @@ And that's it! The Symfony middleware can now make authz requests to the PDP, an
 
 #### Setting up the Symfony server
 
-- [Install Symfony](https://symfony.com/doc/current/setup.html)
-- [Install composer](https://getcomposer.org/download/)
-
 Again, make sure you're in the `/example` directory of this repository, and run
 
 ```
-php composer.phar install -d app
-symfony serve --dir=app
+docker build -t symfony-mw-example
+docker run symfony-mw-example
 ```
 
 Your app is now running.

--- a/src/OpenPolicyAgent.php
+++ b/src/OpenPolicyAgent.php
@@ -107,8 +107,13 @@ class OpenPolicyAgent implements EventSubscriberInterface, LoggerAwareInterface
             return;
         }
         
-        if (!$this->authorize($event, $attribute->getArguments())) {
-            throw new AccessDeniedHttpException('OPA Authz: Deny');
+        try {
+            if (!$this->authorize($event, $attribute->getArguments())) {
+                throw new AccessDeniedHttpException('OPA Authz: Deny');
+            }
+        }
+        catch (\Exception $e) {
+            throw new AccessDeniedHttpException($e->getMessage(), $e);
         }
     }
 


### PR DESCRIPTION
Can now handle a larger variety of input from the configuration.

Example: PDP_HOSTNAME can be localhost, or http://localhost,
or http://localhost/ and so on.